### PR TITLE
Use hipExtLaunchKernelGGL To benchmark HIP Code

### DIFF
--- a/mixbench-hip/mix_kernels_hip.cpp
+++ b/mixbench-hip/mix_kernels_hip.cpp
@@ -6,6 +6,7 @@
 
 #include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
+#include <hip/hip_ext.h>
 #include <stdio.h>
 
 #define HIPRT_INF     __longlong_as_double(0x7ff0000000000000ULL)
@@ -96,6 +97,21 @@ benchmark_func(T seed, T *g_data){
 	}
 }
 
+void initializeEvents_ext(hipEvent_t *start, hipEvent_t *stop){
+	CUDA_SAFE_CALL( hipEventCreate(start) );
+	CUDA_SAFE_CALL( hipEventCreate(stop) );
+}
+
+float finalizeEvents_ext(hipEvent_t start, hipEvent_t stop){
+	CUDA_SAFE_CALL( hipGetLastError() );
+	CUDA_SAFE_CALL( hipEventSynchronize(stop) );
+	float kernel_time;
+	CUDA_SAFE_CALL( hipEventElapsedTime(&kernel_time, start, stop) );
+	CUDA_SAFE_CALL( hipEventDestroy(start) );
+	CUDA_SAFE_CALL( hipEventDestroy(stop) );
+	return kernel_time;
+}
+
 void initializeEvents(hipEvent_t *start, hipEvent_t *stop){
 	CUDA_SAFE_CALL( hipEventCreate(start) );
 	CUDA_SAFE_CALL( hipEventCreate(stop) );
@@ -143,22 +159,22 @@ void runbench(double *cd, long size){
     dim3 dimGrid(TOTAL_BLOCKS, 1, 1);
 	hipEvent_t start, stop;
 
-	initializeEvents(&start, &stop);
-	hipLaunchKernelGGL(HIP_KERNEL_NAME(benchmark_func< float, BLOCK_SIZE, memory_ratio >), dim3(dimGrid), dim3(dimBlock ), 0, 0, 1.0f, (float*)cd);
-	float kernel_time_mad_sp = finalizeEvents(start, stop);
+	initializeEvents_ext(&start, &stop);
+	hipExtLaunchKernelGGL(HIP_KERNEL_NAME(benchmark_func< float, BLOCK_SIZE, memory_ratio >), dim3(dimGrid), dim3(dimBlock ), 0, 0, start, stop, 0, 1.0f, (float*)cd);
+	float kernel_time_mad_sp = finalizeEvents_ext(start, stop);
 
-	initializeEvents(&start, &stop);
-	hipLaunchKernelGGL(HIP_KERNEL_NAME(benchmark_func< double, BLOCK_SIZE, memory_ratio >), dim3(dimGrid), dim3(dimBlock ), 0, 0, 1.0, cd);
-	float kernel_time_mad_dp = finalizeEvents(start, stop);
+	initializeEvents_ext(&start, &stop);
+	hipExtLaunchKernelGGL(HIP_KERNEL_NAME(benchmark_func< double, BLOCK_SIZE, memory_ratio >), dim3(dimGrid), dim3(dimBlock ), 0, 0, start, stop, 0, 1.0, cd);
+	float kernel_time_mad_dp = finalizeEvents_ext(start, stop);
 
-	initializeEvents(&start, &stop);
+	initializeEvents_ext(&start, &stop);
 	half2 h_ones(1.0f);
-	hipLaunchKernelGGL(HIP_KERNEL_NAME(benchmark_func< half2, BLOCK_SIZE, memory_ratio >), dim3(dimGrid), dim3(dimBlock ), 0, 0, h_ones, (half2*)cd);
-	float kernel_time_mad_hp = finalizeEvents(start, stop);
+	hipExtLaunchKernelGGL(HIP_KERNEL_NAME(benchmark_func< half2, BLOCK_SIZE, memory_ratio >), dim3(dimGrid), dim3(dimBlock ), 0, 0, start, stop, 0, h_ones, (half2*)cd);
+	float kernel_time_mad_hp = finalizeEvents_ext(start, stop);
 
-	initializeEvents(&start, &stop);
-	hipLaunchKernelGGL(HIP_KERNEL_NAME(benchmark_func< int, BLOCK_SIZE, memory_ratio >), dim3(dimGrid), dim3(dimBlock ), 0, 0, 1, (int*)cd);
-	float kernel_time_mad_int = finalizeEvents(start, stop);
+	initializeEvents_ext(&start, &stop);
+	hipExtLaunchKernelGGL(HIP_KERNEL_NAME(benchmark_func< int, BLOCK_SIZE, memory_ratio >), dim3(dimGrid), dim3(dimBlock ), 0, 0, start, stop, 0, 1, (int*)cd);
+	float kernel_time_mad_int = finalizeEvents_ext(start, stop);
 
 	const double memaccesses_ratio = (double)(memory_ratio)/UNROLL_ITERATIONS;
 	const double computations_ratio = 1.0-memaccesses_ratio;

--- a/mixbench-hip/mix_kernels_hip_ro.cpp
+++ b/mixbench-hip/mix_kernels_hip_ro.cpp
@@ -77,23 +77,6 @@ float finalizeEvents_ext(hipEvent_t start, hipEvent_t stop){
 	return kernel_time;
 }
 
-void initializeEvents(hipEvent_t *start, hipEvent_t *stop){
-	CUDA_SAFE_CALL( hipEventCreate(start) );
-	CUDA_SAFE_CALL( hipEventCreate(stop) );
-	CUDA_SAFE_CALL( hipEventRecord(*start, 0) );
-}
-
-float finalizeEvents(hipEvent_t start, hipEvent_t stop){
-	CUDA_SAFE_CALL( hipGetLastError() );
-	CUDA_SAFE_CALL( hipEventRecord(stop, 0) );
-	CUDA_SAFE_CALL( hipEventSynchronize(stop) );
-	float kernel_time;
-	CUDA_SAFE_CALL( hipEventElapsedTime(&kernel_time, start, stop) );
-	CUDA_SAFE_CALL( hipEventDestroy(start) );
-	CUDA_SAFE_CALL( hipEventDestroy(stop) );
-	return kernel_time;
-}
-
 void runbench_warmup(double *cd, long size){
 	const long reduced_grid_size = size/(ELEMENTS_PER_THREAD)/128;
 	const int BLOCK_SIZE = 256;
@@ -120,6 +103,7 @@ void runbench(double *cd, long size){
 	hipEvent_t start, stop;
 
 	initializeEvents_ext(&start, &stop);
+	// hipExtLaunchKernelGGL is an extended API which adds event recording as a part of the API
 	hipExtLaunchKernelGGL(HIP_KERNEL_NAME(benchmark_func< float, BLOCK_SIZE, ELEMENTS_PER_THREAD, compute_iterations >), dim3(dimGrid), dim3(dimBlock ), 0, 0, start, stop, 0, 1.0f, (float*)cd);
 	float kernel_time_mad_sp = finalizeEvents_ext(start, stop);
 


### PR DESCRIPTION
HIP has an extended API which has event record as a part of it.
This gives you better picture of the execution time and GFLOPS.
On original API this numbers also contain overhead of event sync time.