### PR TITLE
Fix OpenCL object leaks: command queue and context were not released.

### DIFF
--- a/mixbench-opencl/mix_kernels_ocl.cpp
+++ b/mixbench-opencl/mix_kernels_ocl.cpp
@@ -342,4 +342,6 @@ extern "C" void mixbenchGPU(cl_device_id dev_id, double *c, long size, bool bloc
 
 	// Release buffer
 	OCL_SAFE_CALL( clReleaseMemObject(c_buffer) );
+	OCL_SAFE_CALL( clReleaseCommandQueue(cmd_queue) );
+	OCL_SAFE_CALL( clReleaseContext(context) );
 }

--- a/mixbench-opencl/mix_kernels_ocl_ro.cpp
+++ b/mixbench-opencl/mix_kernels_ocl_ro.cpp
@@ -331,4 +331,6 @@ extern "C" void mixbenchGPU(cl_device_id dev_id, double *c, long size, bool bloc
 
 	// Release buffer
 	OCL_SAFE_CALL( clReleaseMemObject(c_buffer) );
+	OCL_SAFE_CALL( clReleaseCommandQueue(cmd_queue) );
+	OCL_SAFE_CALL( clReleaseContext(context) );
 }


### PR DESCRIPTION
Hello,

While trying to find real life examples for the OpenCL Layer tutorial next week at IWOCL I stumbled upon a memory/handle leak in mixbench-opencl. This pull request should fix the "bug".
Tell me if it is OK if I use this as an example of the benefits of memory validation using layers during my tutorial/demonstration.

Thanks,
Brice