### PR TITLE
Added option to select GPU to CUDA benchmark.

### DIFF
--- a/mixbench-cuda/README.md
+++ b/mixbench-cuda/README.md
@@ -6,3 +6,11 @@ It is actually the original implementation of this benchmark.
 ## Building notes
 
 Building should be straightforward by using the respective `CMakeList.txt` file.
+
+
+## Usage
+
+Use `--gpu` option to select which GPU to benchmark (otherwise defaults to 0), e.g.:
+```bash
+./mixbench-cuda --gpu 2
+```

--- a/mixbench-cuda/main-cuda.cpp
+++ b/mixbench-cuda/main-cuda.cpp
@@ -15,12 +15,45 @@
 
 #define VECTOR_SIZE (32 * 1024 * 1024)
 
+void print_usage(const char* program_name) {
+    printf("Usage: %s [--gpu <GPU_ID>]\n", program_name);
+    printf("Options:\n");
+    printf("  --gpu <GPU_ID>    Specify the GPU ID to use (default: 0)\n");
+}
+
 int main(int argc, char* argv[]) {
     printf("mixbench (%s)\n", VERSION_INFO);
 
+    int gpu_id = 0;
+    int i;
+    for (i=1;i<argc;i++) {
+        if(strcmp(argv[i], "--gpu") == 0) {
+            if(i + 1 < argc) {
+                gpu_id = atoi(argv[i + 1]);
+                if(gpu_id < 0) {
+                    fprintf(stderr, "Error: GPU ID must be a non-negative integer.\n");
+                    print_usage(argv[0]);
+                    return 1;
+                }
+                i++; // Skip the next argument as it's the GPU ID
+            } else {
+                fprintf(stderr, "Error: --gpu option requires an argument.\n");
+                print_usage(argv[0]);
+                return 1;
+            }
+        } else if(strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+            print_usage(argv[0]);
+            return 0;
+        } else {
+            fprintf(stderr, "Error: Unknown option '%s'\n", argv[i]);
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
     unsigned int datasize = VECTOR_SIZE * sizeof(double);
 
-    cudaSetDevice(0);
+    cudaSetDevice(gpu_id);
     StoreDeviceInfo(stdout);
 
     size_t freeCUDAMem, totalCUDAMem;


### PR DESCRIPTION
I had a bit of fun with this nifty little utility, I had to make a small modification to allow me to benchmark multiple GPUs on the same system. It's a really minor change, just added an optional `--gpu` argument e.g.
```bash
./mixbench-cuda --gpu 2
```
It still defaults to GPU 0 if no argument is passed.