### PR TITLE
cpu: use stable clock

### DIFF
--- a/mixbench-cpu/mix_kernels_cpu.cpp
+++ b/mixbench-cpu/mix_kernels_cpu.cpp
@@ -16,6 +16,8 @@
 
 const auto base_omp_get_max_threads = omp_get_max_threads();
 
+using benchmark_clock = std::chrono::steady_clock;
+
 #ifdef BASELINE_IMPL
 
 template <typename Element, size_t compute_iterations, size_t static_chunk_size>
@@ -104,20 +106,20 @@ __attribute__((optimize("unroll-loops"))) size_t bench(size_t len,
 }
 
 auto runbench_warmup(double* c, size_t size) {
-  auto timer_start = std::chrono::high_resolution_clock::now();
+  auto timer_start = benchmark_clock::now();
 
   bench<double, 16>(size, 1., -1., c);
 
-  auto timer_duration = std::chrono::high_resolution_clock::now() - timer_start;
+  auto timer_duration = benchmark_clock::now() - timer_start;
   return std::chrono::duration_cast<std::chrono::microseconds>(timer_duration)
       .count();
 }
 
 template <typename Op>
 auto measure_operation(Op op) {
-  auto timer_start = std::chrono::high_resolution_clock::now();
+  auto timer_start = benchmark_clock::now();
   op();
-  auto timer_duration = std::chrono::high_resolution_clock::now() - timer_start;
+  auto timer_duration = benchmark_clock::now() - timer_start;
   return std::chrono::duration_cast<std::chrono::microseconds>(timer_duration)
              .count() /
          1000.;


### PR DESCRIPTION
Use stable clock instead of high performance clock as it proved it is unstable on 13th gen Intel CPU, e.g.:

```
mixbench-cpu (v0.04-13-g597b700)
Use "-h" argument to see available options
Working memory size: 384MB
Total threads: 12
---------------------------------------------------------- CSV data ----------------------------------------------------------
Experiment ID, Single Precision ops,,,,              Double precision ops,,,,              Integer operations,,,
Compute iters, Flops/byte, ex.time,  GFLOPS, GB/sec, Flops/byte, ex.time,  GFLOPS, GB/sec, Iops/byte, ex.time,   GIOPS, GB/sec
            0,      0.250,   20.65,    4.87,  19.50,      0.125,   19.52,    2.58,  20.63,     0.250,   20.03,    5.03,  20.10
            1,      0.750,   19.56,   15.44,  20.59,      0.375,   19.50,    7.74,  20.65,     0.750,   19.38,   15.58,  20.77
            2,      1.250,   19.21,   26.21,  20.96,      0.625,   19.39,   12.98,  20.77,     1.250,   19.46,   25.87,  20.69
            3,      1.750,   19.44,   36.25,  20.71,      0.875,   19.76,   17.83,  20.37,     1.750,   19.37,   36.38,  20.79
            4,      2.250,-23159.46,   -0.04,  -0.02,      1.125,   19.37,   23.39,  20.79,     2.250,   19.27,   47.01,  20.89
            6,      3.250,   19.21,   68.12,  20.96,      1.625,   19.18,   34.12,  20.99,     3.250,   19.23,   68.05,  20.94
            8,      4.250,   19.27,   88.81,  20.90,      2.125,   19.19,   44.59,  20.98,     4.250,-23161.54,   -0.07,  -0.02
           12,      6.250,   19.32,  130.26,  20.84,      3.125,   19.39,   64.88,  20.76,     6.250,   19.31,  130.33,  20.85
           16,      8.250,   19.35,  171.68,  20.81,      4.125,   19.29,   86.11,  20.87,     8.250,   19.51,  170.25,  20.64
           20,     10.250,   19.34,  213.36,  20.82,      5.125,   19.34,  106.68,  20.82,    10.250,-23161.84,   -0.18,  -0.02
           24,     12.250,   19.42,  254.03,  20.74,      6.125,   19.29,  127.83,  20.87,    12.250,   20.89,  236.10,  19.27
           28,     14.250,   19.49,  294.40,  20.66,      7.125,   19.41,  147.81,  20.75,    14.250,   23.83,  240.76,  16.90
           32,     16.250,   19.56,  334.50,  20.58,      8.125,   19.45,  168.23,  20.71,    16.250,   26.75,  244.64,  15.05
           40,     20.250,   19.81,  411.51,  20.32,     10.125,   19.79,  206.06,  20.35,    20.250,   34.19,  238.52,  11.78
           48,     24.250,   20.45,  477.57,  19.69,     12.125,-23158.32,   -0.21,  -0.02,    24.250,-23141.24,   -0.42,  -0.02
           56,     28.250,   21.62,  526.06,  18.62,     14.125,   21.48,  264.83,  18.75,    28.250,   48.81,  233.03,   8.25
           64,     32.250,-23150.58,   -0.56,  -0.02,     16.125,   25.08,  258.88,  16.05,    32.250,   61.37,  211.58,   6.56
           80,     40.250,   33.31,  486.47,  12.09,     20.125,-23141.40,   -0.35,  -0.02,    40.250,   79.53,  203.79,   5.06
          104,     52.250,-23124.38,   -0.91,  -0.02,     26.125,   39.46,  266.59,  10.20,    52.250,   97.14,  216.58,   4.15
          120,     60.250,-23128.46,   -1.05,  -0.02,     30.125,   46.70,  259.75,   8.62,    60.250,-23054.74,   -1.05,  -0.02
          128,     64.250,   49.69,  520.67,   8.10,     32.125,   49.12,  263.37,   8.20,    64.250,  125.06,  206.86,   3.22
          160,     80.250,-23116.23,   -1.40,  -0.02,     40.125,   55.39,  291.66,   7.27,    80.250,  166.41,  194.18,   2.42
          192,     96.250,-23106.90,   -1.68,  -0.02,     48.125,-23073.44,   -0.84,  -0.02,    96.250,  195.74,  198.00,   2.06
          256,    128.250,   93.33,  553.33,   4.31,     64.125,   91.52,  282.14,   4.40,   128.250,-22887.28,   -2.26,  -0.02
          320,    160.250,  147.14,  438.52,   2.74,     80.125,-23015.59,   -1.40,  -0.02,   160.250,  384.21,  167.94,   1.05
          512,    256.250,    2.51,41140.30, 160.55,    128.125, -180.22, -286.26,  -2.23,   256.250,  528.95,  195.07,   0.76
------------------------------------------------------------------------------------------------------------------------------
```