### PR TITLE
fix: compile for native cuda architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,13 @@ mixbench-ocl
 mixbench-sycl
 mixbench-cpu
 
+# But not the code itself
+!mixbench-cuda/
+!mixbench-hip/
+!mixbench-ocl/
+!mixbench-sycl/
+!mixbench-cpu/
+
 # Debug files
 *.dSYM/
 

--- a/mixbench-cuda/CMakeLists.txt
+++ b/mixbench-cuda/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories(${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
 string(APPEND CMAKE_CUDA_FLAGS " -Xptxas=-v")
 string(APPEND CMAKE_CUDA_FLAGS " -Wno-deprecated-gpu-targets")
 string(APPEND CMAKE_CUDA_FLAGS " --cudart=static")
-string(APPEND CMAKE_CUDA_FLAGS " -gencode arch=compute_52,code=[sm_52,compute_52] -gencode arch=compute_61,code=compute_61")
+string(APPEND CMAKE_CUDA_FLAGS " -arch=native")
 
 # Get version info from git tag
 execute_process(COMMAND git describe --tags --always

--- a/mixbench-cuda/CMakeLists.txt
+++ b/mixbench-cuda/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 project(mixbench LANGUAGES CXX CUDA)
 
 # Include CUDA header directory in cpp files
@@ -7,7 +7,6 @@ include_directories(${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
 string(APPEND CMAKE_CUDA_FLAGS " -Xptxas=-v")
 string(APPEND CMAKE_CUDA_FLAGS " -Wno-deprecated-gpu-targets")
 string(APPEND CMAKE_CUDA_FLAGS " --cudart=static")
-string(APPEND CMAKE_CUDA_FLAGS " -arch=native")
 
 # Get version info from git tag
 execute_process(COMMAND git describe --tags --always

--- a/mixbench-cuda/README.md
+++ b/mixbench-cuda/README.md
@@ -3,9 +3,11 @@
 This is the CUDA implementation of mixbench.
 It is actually the original implementation of this benchmark.
 
-## Building locally
+## Building
 
 To build the executable, run the following commands.
+
+> The minimum required CMake version is 3.18.
 
 ```sh
 mkdir build
@@ -17,27 +19,15 @@ cmake --build ./
 This will build and write a `mixbench-cuda` executable file in the `build/`
 directory, compiled with support for the native CUDA architecture. Note that
 the `-arch=native` flag was [introduced in CUDA 11.5 update 1][1]. If you
-are using a prior version, follow the below instructions to compile for a given
-architecture.
+are using a prior version, or wish to compile the program for a specific
+architecture, replace `native` in the above command with the architecture.
+For example, to compile for the `sm_120` architecture, we would run:
 
-## Building for specific architectures
-
-If you wish to compile the program for specific architectures, i.e., `sm_120`
-and `sm_52`, edit `CMakeLists.txt` in this directory and change the following
-line as shown below.
-
-```diff
---- a/mixbench-cuda/CMakeLists.txt
-+++ b/mixbench-cuda/CMakeLists.txt
-@@ -7,7 +7,7 @@ include_directories(${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
- string(APPEND CMAKE_CUDA_FLAGS " -Xptxas=-v")
- string(APPEND CMAKE_CUDA_FLAGS " -Wno-deprecated-gpu-targets")
- string(APPEND CMAKE_CUDA_FLAGS " --cudart=static")
--string(APPEND CMAKE_CUDA_FLAGS " -arch=native")
-+string(APPEND CMAKE_CUDA_FLAGS " -gencode arch=compute_120,code=[sm_120,compute_120] -gencode arch=compute_52,code=compute_52")
-
- # Get version info from git tag
- execute_process(COMMAND git describe --tags --always
+```
+mkdir build
+cd build
+cmake ../mixbench-cuda -DCMAKE_CUDA_ARCHITECTURES=sm_120
+cmake --build ./
 ```
 
 [1]: https://docs.nvidia.com/cuda/cuda-features-archive/index.html#compiler

--- a/mixbench-cuda/README.md
+++ b/mixbench-cuda/README.md
@@ -3,6 +3,41 @@
 This is the CUDA implementation of mixbench.
 It is actually the original implementation of this benchmark.
 
-## Building notes
+## Building locally
 
-Building should be straightforward by using the respective `CMakeList.txt` file.
+To build the executable, run the following commands.
+
+```sh
+mkdir build
+cd build
+cmake ../mixbench-cuda -DCMAKE_CUDA_ARCHITECTURES=native
+cmake --build ./
+```
+
+This will build and write a `mixbench-cuda` executable file in the `build/`
+directory, compiled with support for the native CUDA architecture. Note that
+the `-arch=native` flag was [introduced in CUDA 11.5 update 1][1]. If you
+are using a prior version, follow the below instructions to compile for a given
+architecture.
+
+## Building for specific architectures
+
+If you wish to compile the program for specific architectures, i.e., `sm_120`
+and `sm_52`, edit `CMakeLists.txt` in this directory and change the following
+line as shown below.
+
+```diff
+--- a/mixbench-cuda/CMakeLists.txt
++++ b/mixbench-cuda/CMakeLists.txt
+@@ -7,7 +7,7 @@ include_directories(${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+ string(APPEND CMAKE_CUDA_FLAGS " -Xptxas=-v")
+ string(APPEND CMAKE_CUDA_FLAGS " -Wno-deprecated-gpu-targets")
+ string(APPEND CMAKE_CUDA_FLAGS " --cudart=static")
+-string(APPEND CMAKE_CUDA_FLAGS " -arch=native")
++string(APPEND CMAKE_CUDA_FLAGS " -gencode arch=compute_120,code=[sm_120,compute_120] -gencode arch=compute_52,code=compute_52")
+
+ # Get version info from git tag
+ execute_process(COMMAND git describe --tags --always
+```
+
+[1]: https://docs.nvidia.com/cuda/cuda-features-archive/index.html#compiler


### PR DESCRIPTION
- fix the `.gitignore` file so it does not ignore the top-level directories themselves, and instead ignores the executables within any directories.
- change the target architecture/gencode for `nvcc` to `native` so that it auto-detects and builds the executable for the installed CUDA version.
- expand the documentation to include commands on building with the default (`native`) architecture and for specific architectures.