### PR TITLE
fix(cpu): drop reinterpret cast to address UB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ mixbench-cpu/build*/
 
 # Other
 version_info.h
+
+# VS Code IDE
+.vscode/

--- a/mixbench-cpu/CMakeLists.txt
+++ b/mixbench-cpu/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/mixbench-cpu/main.cpp
+++ b/mixbench-cpu/main.cpp
@@ -7,6 +7,7 @@
 #include <omp.h>
 
 #include <chrono>
+#include <cstddef>
 #include <cstring>
 #include <iostream>
 #include <memory>
@@ -64,15 +65,15 @@ int main(int argc, char* argv[]) {
 
   const size_t VEC_WIDTH = 1024 * 1024 * args.vecwidth;
 
-  std::unique_ptr<double[]> c;
+  std::unique_ptr<std::byte[]> c;
 
-  c.reset(new (std::align_val_t(64)) double[VEC_WIDTH]);
+  c.reset(new (std::align_val_t(64)) std::byte[VEC_WIDTH * sizeof(double)]);
 
   std::cout << "Working memory size: " << args.vecwidth * sizeof(double) << "MB"
             << std::endl;
   std::cout << "Total threads: " << hardware_concurrency << std::endl;
 
-  mixbenchCPU(c.get(), VEC_WIDTH);
+  mixbenchCPU(c.get(), VEC_WIDTH * sizeof(double));
 
   return 0;
 }

--- a/mixbench-cpu/mix_kernels_cpu.cpp
+++ b/mixbench-cpu/mix_kernels_cpu.cpp
@@ -11,7 +11,6 @@
 #include <chrono>
 #include <iomanip>
 #include <iostream>
-#include <memory>
 #include <vector>
 
 const auto base_omp_get_max_threads = omp_get_max_threads();

--- a/mixbench-cpu/mix_kernels_cpu.cpp
+++ b/mixbench-cpu/mix_kernels_cpu.cpp
@@ -104,10 +104,14 @@ __attribute__((optimize("unroll-loops"))) size_t bench(size_t len,
   return len;
 }
 
-auto runbench_warmup(double* c, size_t size) {
+auto runbench_warmup(void* c, size_t size) {
+  const int num_elements = size / sizeof(double);
   auto timer_start = benchmark_clock::now();
 
-  bench<double, 16>(size, 1., -1., c);
+  // initialize memory to avoid UB
+  double* ptr = new (c) double[num_elements];
+
+  bench<double, 16>(num_elements, 1., -1., ptr);
 
   auto timer_duration = benchmark_clock::now() - timer_start;
   return std::chrono::duration_cast<std::chrono::microseconds>(timer_duration)
@@ -169,8 +173,7 @@ class ComputeSpace {
             * compute_iterations_ /* Core loop iteration count */
             * 2                   /* Flops per core loop iteration */
             * 1                   /* FMAs in the inner most loop */
-        + total_elements - 1      /* Due to sum reduction */
-        ;
+        + total_elements - 1;     /* Due to sum reduction */
     return computations;
   }
 
@@ -183,29 +186,34 @@ class ComputeSpace {
 };
 
 template <unsigned int compute_iterations>
-void runbench(double* c, size_t size) {
-  ComputeSpace cs{size * sizeof(double), compute_iterations};
+void runbench(void* c, size_t size) {
+  ComputeSpace cs{size, compute_iterations};
 
   // floating point part (single prec)
+  // initialize memory to avoid UB
+  new (c) float[cs.element_count<float>()];
   auto kernel_time_mad_sp = benchmark_omp([&] {
     return measure_operation([&] {
       bench<float, compute_iterations>(cs.element_count<float>(), 1.f, -1.f,
-                                       reinterpret_cast<float*>(c));
+                                       static_cast<float*>(c));
     });
   });
 
   // floating point part (double prec)
+  new (c) double[cs.element_count<double>()];
   auto kernel_time_mad_dp = benchmark_omp([&] {
     return measure_operation([&] {
-      bench<double, compute_iterations>(cs.element_count<double>(), 1., -1., c);
+      bench<double, compute_iterations>(cs.element_count<double>(), 1., -1.,
+                                        static_cast<double*>(c));
     });
   });
 
   // integer part
+  new (c) int[cs.element_count<int>()];
   auto kernel_time_mad_int = benchmark_omp([&] {
     return measure_operation([&] {
       bench<int, compute_iterations>(cs.element_count<int>(), 1, -1,
-                                     reinterpret_cast<int*>(c));
+                                     static_cast<int*>(c));
     });
   });
 
@@ -255,21 +263,21 @@ void runbench(double* c, size_t size) {
 
 // Variadic template helper to ease multiple configuration invocations
 template <unsigned int compute_iterations>
-void runbench_range(double* cd, long size) {
+void runbench_range(void* cd, size_t size) {
   runbench<compute_iterations>(cd, size);
 }
 
 template <unsigned int j1, unsigned int j2, unsigned int... Args>
-void runbench_range(double* cd, long size) {
+void runbench_range(void* cd, size_t size) {
   runbench_range<j1>(cd, size);
   runbench_range<j2, Args...>(cd, size);
 }
 
-void mixbenchCPU(double* c, size_t size) {
-// Initialize data to zeros on memory by respecting 1st touch policy
+void mixbenchCPU(void* c, size_t size) {
+  // Initialize data to zeros on memory by respecting 1st touch policy
 #pragma omp parallel for schedule(static)
-  for (size_t i = 0; i < size; i++)
-    c[i] = 0.0;
+  for (size_t i = 0; i < size / sizeof(int); i++)
+    ((int*)c)[i] = 0;
 
   std::cout << "--------------------------------------------"
                "-------------- CSV data "

--- a/mixbench-cpu/mix_kernels_cpu.cpp
+++ b/mixbench-cpu/mix_kernels_cpu.cpp
@@ -191,29 +191,29 @@ void runbench(void* c, size_t size) {
 
   // floating point part (single prec)
   // initialize memory to avoid UB
-  new (c) float[cs.element_count<float>()];
+  float *c_as_float = new (c) float[cs.element_count<float>()];
   auto kernel_time_mad_sp = benchmark_omp([&] {
     return measure_operation([&] {
       bench<float, compute_iterations>(cs.element_count<float>(), 1.f, -1.f,
-                                       static_cast<float*>(c));
+                                       c_as_float);
     });
   });
 
   // floating point part (double prec)
-  new (c) double[cs.element_count<double>()];
+  double *c_as_double = new (c) double[cs.element_count<double>()];
   auto kernel_time_mad_dp = benchmark_omp([&] {
     return measure_operation([&] {
       bench<double, compute_iterations>(cs.element_count<double>(), 1., -1.,
-                                        static_cast<double*>(c));
+                                        c_as_double);
     });
   });
 
   // integer part
-  new (c) int[cs.element_count<int>()];
+  int *c_as_int = new (c) int[cs.element_count<int>()];
   auto kernel_time_mad_int = benchmark_omp([&] {
     return measure_operation([&] {
       bench<int, compute_iterations>(cs.element_count<int>(), 1, -1,
-                                     static_cast<int*>(c));
+                                     c_as_int);
     });
   });
 

--- a/mixbench-cpu/mix_kernels_cpu.h
+++ b/mixbench-cpu/mix_kernels_cpu.h
@@ -1,5 +1,6 @@
 /**
- * mix_kernels_cpu.h: This file is part of the mixbench GPU micro-benchmark suite.
+ * mix_kernels_cpu.h: This file is part of the mixbench GPU micro-benchmark
+ * suite.
  *
  * Contact: Elias Konstantinidis <ekondis@gmail.com>
  **/

--- a/mixbench-cpu/mix_kernels_cpu.h
+++ b/mixbench-cpu/mix_kernels_cpu.h
@@ -8,6 +8,6 @@
 #ifndef _MIX_KERNELS_CPU_H_
 #define _MIX_KERNELS_CPU_H_
 
-void mixbenchCPU(double*, size_t);
+void mixbenchCPU(void*, size_t);
 
 #endif

--- a/mixbench-opencl/CMakeLists.txt
+++ b/mixbench-opencl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(mixbench-ocl LANGUAGES CXX)
 
 find_package(OpenCL REQUIRED)

--- a/mixbench-sycl/CMakeLists.txt
+++ b/mixbench-sycl/CMakeLists.txt
@@ -1,5 +1,4 @@
-# required cmake version
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Try an alternative approach to avoid UB induced by the use of reinterpret cast.